### PR TITLE
Initial commits to bundle creation from anndata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# atlas-anndata
-Tools for anndata generation/ consumption for Expression Atlas 
+# Single-cell Expression Atlas - compatible analysis bundles from annData files
+
+In the Gene Expression team at the EBI we produce [Single Cell Expression Atlas](https://www.ebi.ac.uk/gxa/sc/home), using a consistent pipeline to analyse data from the raw FASTQ files and produce the results visibile in the SCXA interface. Intermediate in this process is an 'analysis bundle' whereby the subset of results needed are gathered and formatted correctly for loading into our databases and indices. 
+
+We sometimes encounter datasets without raw data, but where the user has an [annData](https://anndata.readthedocs.io/en/latest/) file containing expression matrices and derived results. The purpose of this repository is to provide a way of producing an analysis bundle directly from an annData object, allowing us (with some manual curation) to input these experiments. It will also be useful to simplify our own processes, since we can take the annData files now produced at the end of our analysis to produce a bundle in one step.
+
+## Example commands  

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ In the Gene Expression team at the EBI we produce [Single Cell Expression Atlas]
 
 We sometimes encounter datasets without raw data, but where the user has an [annData](https://anndata.readthedocs.io/en/latest/) file containing expression matrices and derived results. The purpose of this repository is to provide a way of producing an analysis bundle directly from an annData object, allowing us (with some manual curation) to input these experiments. It will also be useful to simplify our own processes, since we can take the annData files now produced at the end of our analysis to produce a bundle in one step.
 
+This is the implementation of an [internal strategy document](https://docs.google.com/document/d/1sdy9iOHKXUz8dEv66v1Cu77626_w2KuJ2myapWIN5So/edit#heading=h.mdsu1vbn6spl).
+
 ## Analysis bundles
 
 ### What make analysis bundle?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,177 @@
 # Single-cell Expression Atlas - compatible analysis bundles from annData files
 
-In the Gene Expression team at the EBI we produce [Single Cell Expression Atlas](https://www.ebi.ac.uk/gxa/sc/home), using a consistent pipeline to analyse data from the raw FASTQ files and produce the results visibile in the SCXA interface. Intermediate in this process is an 'analysis bundle' whereby the subset of results needed are gathered and formatted correctly for loading into our databases and indices. 
+In the Gene Expression team at the EBI we produce [Single Cell Expression Atlas](https://www.ebi.ac.uk/gxa/sc/home) (SCXA), using a consistent pipeline to analyse data from the raw FASTQ files and produce the results visibile in the SCXA interface. Intermediate in this process is an 'analysis bundle' whereby the subset of results needed are gathered and formatted correctly for loading into our databases and indices. 
 
 We sometimes encounter datasets without raw data, but where the user has an [annData](https://anndata.readthedocs.io/en/latest/) file containing expression matrices and derived results. The purpose of this repository is to provide a way of producing an analysis bundle directly from an annData object, allowing us (with some manual curation) to input these experiments. It will also be useful to simplify our own processes, since we can take the annData files now produced at the end of our analysis to produce a bundle in one step.
+
+## Analysis bundles
+
+### What make analysis bundle?
+
+An SCXA analysis bundle contains:
+
+ - MTX-format expression matrices (raw, filtered, normalised)
+ - TSV-format cell metadata used in analysis
+ - TSV-format gene metadata used in analysis
+ - TSV-format dimension reductions of different parameterisation (t-SNE, UMAP)
+ - An annData-format file containing all the above
+ - Reference files (GTF, cDNA) used in analysis
+ - A software report detailing tools and versions used
+ - A manifest file containing all the above
+
+### MANIFEST
+
+Here is an example manifest:
+
+```
+Description	File	Parameterisation
+software_versions_file	software.tsv	
+mtx_matrix_rows	filtered_normalised/genes.tsv.gz	filtered_normalised
+mtx_matrix_cols	filtered_normalised/barcodes.tsv.gz	filtered_normalised
+mtx_matrix_content	filtered_normalised/matrix.mtx.gz	filtered_normalised
+tsv_matrix	filtered_normalised/filtered_normalised.tsv	filtered_normalised
+mtx_matrix_rows	tpm/genes.tsv.gz	tpm
+mtx_matrix_cols	tpm/barcodes.tsv.gz	tpm
+mtx_matrix_content	tpm/matrix.mtx.gz	tpm
+tsv_matrix	tpm/tpm.tsv	tpm
+mtx_matrix_rows	raw/genes.tsv.gz	raw
+mtx_matrix_cols	raw/barcodes.tsv.gz	raw
+mtx_matrix_content	raw/matrix.mtx.gz	raw
+tsv_matrix	raw/raw.tsv	raw
+mtx_matrix_rows	raw_filtered/genes.tsv.gz	raw_filtered
+mtx_matrix_cols	raw_filtered/barcodes.tsv.gz	raw_filtered
+mtx_matrix_content	raw_filtered/matrix.mtx.gz	raw_filtered
+tsv_matrix	raw_filtered/raw_filtered.tsv	raw_filtered
+mtx_matrix_rows	tpm_filtered/genes.tsv.gz	tpm_filtered
+mtx_matrix_cols	tpm_filtered/barcodes.tsv.gz	tpm_filtered
+mtx_matrix_content	tpm_filtered/matrix.mtx.gz	tpm_filtered
+tsv_matrix	tpm_filtered/tpm_filtered.tsv	tpm_filtered
+cell_metadata	E-MTAB-6077.cell_metadata.tsv	
+condensed_sdrf	E-MTAB-6077.condensed-sdrf.tsv	
+project_file	E-MTAB-6077.project.h5ad	
+reference_transcriptome	reference/Danio_rerio.GRCz11.cdna.all.104.fa.gz	
+reference_annotation	reference/Danio_rerio.GRCz11.104.gtf.gz	
+gene_metadata	reference/gene_annotation.txt	
+protocol smart-seq
+tsne_embeddings	tsne_perplexity_1.tsv	1
+tsne_embeddings	tsne_perplexity_10.tsv	10
+umap_embeddings	umap_n_neighbors_10.tsv	10
+umap_embeddings	umap_n_neighbors_100.tsv	100
+cluster_markers	markers_2.tsv	2
+cluster_markers	markers_23.tsv	23
+cluster_markers	markers_32.tsv	32
+cluster_markers	markers_42.tsv	42
+cluster_markers	markers_49.tsv	49
+cluster_markers	markers_5.tsv	5
+marker_stats	filtered_normalised_stats.csv	filtered_normalised
+marker_stats	tpm_filtered_stats.csv	tpm_filtered
+cluster_memberships	clusters_for_bundle.txt
+```
+
+## Command help
+
+Here is the description of options for the main bundle generation script:
+
+```
+> bundle_from_anndata.py --help
+Usage: bundle_from_anndata.py [OPTIONS] ANNDATA_FILE BUNDLE_DIR
+
+  Build a bundle directory compatible with Single Cell Expression Atlas (SCXA)
+  build proceseses
+
+  anndata_file - A file of the annData hdf5 specification, with all necessary information for SCXA.
+  bundle_dir   - A directory in which to create the bundle.
+
+Options:
+  --exp-name TEXT                 Specify an Expression Atlas identifier that
+                                  will be used for this experiment. If not
+                                  set, a placeholder value E-EXP-1234 will be
+                                  used and can be edited in the bundle later.
+  --droplet                       Is this a droplet experiment?
+  --exp-desc PATH                 Provide an experiment description file. If
+                                  unspecified, the script will check for a
+                                  slot called "experiment" in the .uns slot of
+                                  the annData object, and use that to create a
+                                  starting version of an IDF file.
+  --write-cellmeta / --no-write-cellmeta
+                                  Write a table of cell-wise metadata from
+                                  .obs.
+  --write-genemeta / --no-write-genemeta
+                                  Write a table of gene-wise metadata from
+                                  .var.
+  --nonmeta-obs-patterns TEXT[,TEXT...]
+                                  A comma-separated list of patterns to be
+                                  used to exlude columns when writing cell
+                                  metadata from .obs. Defaults to
+                                  louvain,n_genes,n_counts,pct_,total_counts
+  --nonmeta-var-patterns TEXT[,TEXT...]
+                                  A comma-separated list of patterns to be
+                                  used to exlude columns when writing gene
+                                  metadata from .obs. Defaults to mean,counts,
+                                  n_cells,highly_variable,dispersion
+  --raw-matrix-slot TEXT          Slot where the most raw and least filtered
+                                  expression data are stored. This is usually
+                                  in raw.X, other values will be interpreted
+                                  as layers (in .raw if prefixed with "raw".
+                                  annData requires that .raw.X and .X match in
+                                  .obs, so even when stored in .raw this will
+                                  have to be the matrix afer cell filtering,
+                                  but should ideally not be gene-filtered.
+  --filtered-matrix-slot TEXT     Layer name or "X", specifying storage
+                                  location for gene-filtered matrix before
+                                  transformations such as log transform,
+                                  scaling etc.
+  --normalised-matrix-slot TEXT   Layer name or "X", specifiying storage
+                                  location for normalised matrix.
+  --final-matrix-slot TEXT        Layer name or "X", specifiying storage
+                                  location for the final matrix after
+                                  processing. Will usually be in .X.
+  --write-obsms / --no-write-obsms
+                                  Write dimension reductions from .obsm to the
+                                  bundle?
+  --obsms TEXT[,TEXT...]          A comma-separated list of obsm slots to
+                                  write. Default is to write them all.
+  --write-clusters / --no--write--clusters
+                                  Write cluster data to the bundle?
+  --clusters TEXT[,TEXT...]       A comma-separated list of .obs slots
+                                  corresponding to unsupervised clusterings.
+  --clusters-field-pattern TEXT   If --clusters not supplied, a string to be
+                                  used to select columns from .obs
+                                  representing unsupervised clusterings.
+  --default-clustering TEXT       Where --write-clusters is set, which
+                                  clustering should be set as the default? If
+                                  not set, the middle (or first middle)
+                                  clustering will be selected, or if --atlas-
+                                  style is set, this will be the clustering
+                                  corresponding to a resolution of 1.
+  --write-markers / --no--write--markers
+                                  Write marker data to the bundle?
+  --marker-clusterings TEXT[,TEXT...]
+                                  A comma-separated list of clusterings for
+                                  which to write markers. marker results are
+                                  expected to be stored in .uns under keys
+                                  like "markers_{clustering}. Defaults to all
+                                  selected clusterings.
+  --metadata-marker-fields TEXT[,TEXT...]
+                                  A comma-separated list of .obs slots
+                                  corresponding to metadata variables for
+                                  which markers have been derived.
+  --write-marker-stats / --no--write--marker-stats
+                                  Write marker summary statistics (mean,
+                                  median expression) to the bundle?
+  --marker-stats-layers TEXT[,TEXT...]
+                                  A comma-separated list of layers from which
+                                  expression values should be summarised in
+                                  marker statistics.
+  --max-rank-for-stats INTEGER    For how many top marker genes should stats
+                                  (mean, median expression) be output?
+  --atlas-style TEXT              Assume the tight conventions from SCXA, e.g.
+                                  on .obsm slot naming
+  --gene-name-field TEXT          Field in .var where gene name (symbol) is
+                                  stored.
+  --write-anndata / --no--write--anndata
+                                  Write the annData file itself to the bundle?
+  --help                          Show this message and exit.
+```
 
 ## Example commands  

--- a/bin/bundle_from_anndata.py
+++ b/bin/bundle_from_anndata.py
@@ -8,19 +8,25 @@ import pathlib
 import pandas as pd
 import gzip
 import os
+from collections import OrderedDict
+from scanpy_scripts.click_utils import  CommaSeparatedText
+import re
 
 @click.command()
 @click.argument('anndata_file', type=click.Path(exists=True))
 @click.argument('bundle_dir', type=click.Path(dir_okay=True))
 @click.option('--droplet', default=False, help='Specify that this is a droplet experiment. There must be an obs parameter that can be used to differentiate cells from different runs.')
-@click.option('--runObs', default='run', help='The column in obs that differentiates cells from different runs. Will be used to separate run-wise and cell-wise metdata.')
-@click.option('--expDesc', default=None, help='Provide an experiment description file. If unspecified, the script will check for a slot called "experiment" in the .uns slot of the annData object, and use that to create a starting version of an IDF file.', type=click.Path(exists=True))
-@click.option('--rawMatrixSlot', default=None, help='Slot where the most raw and least filtered expression data are stored. This is usually in raw.X, other values will be interpreted as layers (in .raw if prefixed with "raw". annData requires that .raw.X and .X match in .obs, so even when stored in .raw this will have to be the matrix afer cell filtering, but should ideally not be gene-filtered.')
-@click.option('--filteredMatrixSlot', default=None, help='Layer name or "X", specifying storage location for gene-filtered matrix before transformations such as log transform, scaling etc.')
-@click.option('--normalisedMatrixSlot', default=None, help='Layer name or "X", specifiying storage location for normalised matrix.')
-@click.option('--finalMatrixSlot', default=None, help='Layer name or "X", specifiying storage location for the final matrix after processing. Will usually be in .X.')
+@click.option('--run-obs', default='run', help='The column in obs that differentiates cells from different runs. Will be used to separate run-wise and cell-wise metdata.')
+@click.option('--exp-desc', default=None, help='Provide an experiment description file. If unspecified, the script will check for a slot called "experiment" in the .uns slot of the annData object, and use that to create a starting version of an IDF file.', type=click.Path(exists=True))
+@click.option('--raw-matrix-slot', default=None, help='Slot where the most raw and least filtered expression data are stored. This is usually in raw.X, other values will be interpreted as layers (in .raw if prefixed with "raw". annData requires that .raw.X and .X match in .obs, so even when stored in .raw this will have to be the matrix afer cell filtering, but should ideally not be gene-filtered.')
+@click.option('--filtered-matrix-slot', default=None, help='Layer name or "X", specifying storage location for gene-filtered matrix before transformations such as log transform, scaling etc.')
+@click.option('--normalised-matrix-slot', default=None, help='Layer name or "X", specifiying storage location for normalised matrix.')
+@click.option('--final-matrix-slot', default=None, help='Layer name or "X", specifiying storage location for the final matrix after processing. Will usually be in .X.')
+@click.option('--write-obsms/--no--write--obsms', default=True, is_flag=True, help='Write dimension reductions from .obsm to the bundle?')
+@click.option('--obsms', type=CommaSeparatedText(), default='all', help='Either "all" or a comma-separated list of obsm slots to write.')
+@click.option('--atlas-style', default='run', help='Assume the tight conventions from SCXA, e.g. on .obsm slot naming')
 
-def create_bundle(anndata_file, bundle_dir, droplet=False, runobs='run', expdesc=None, rawmatrixslot=None, filteredmatrixslot=None, normalisedmatrixslot=None, finalmatrixslot=None):
+def create_bundle(anndata_file, bundle_dir, droplet=False, run_obs='run', exp_desc=None, raw_matrix_slot=None, filtered_matrix_slot=None, normalised_matrix_slot=None, final_matrix_slot=None, write_obsms=True, obsms='all', atlas_style=True):
     """Build a bundle directory compatible with Single Cell Expression Atlas (SCXA) build proceseses
    
     \b 
@@ -33,33 +39,81 @@ def create_bundle(anndata_file, bundle_dir, droplet=False, runobs='run', expdesc
 
     manifest=_read_file_manifest(bundle_dir)
 
-    if rawmatrixslot is not None:
+    if raw_matrix_slot is not None:
         print("Storing raw matrix")
-        manifest = _write_matrix_from_adata(manifest, adata, slot=rawmatrixslot, bundle_dir=bundle_dir, subdir='raw')        
-
-    if filteredmatrixslot is not None:
+        manifest = _write_matrix_from_adata(manifest, adata, slot=raw_matrix_slot, bundle_dir=bundle_dir, subdir='raw')        
+    
+    if filtered_matrix_slot is not None:
         print("Storing filtered matrix")
-        manifest = _write_matrix_from_adata(manifest, adata, slot=filteredmatrixslot, bundle_dir=bundle_dir, subdir='raw_filtered')        
+        manifest = _write_matrix_from_adata(manifest, adata, slot=filtered_matrix_slot, bundle_dir=bundle_dir, subdir='raw_filtered')         
+    
+    if normalised_matrix_slot is not None:
+        print("Storing normalised matrix")
+        manifest = _write_matrix_from_adata(manifest, adata, slot=normalised_matrix_slot, bundle_dir=bundle_dir, subdir='filtered_normalised')         
+    
+    if final_matrix_slot is not None:
+        print("Storing normalised matrix")
+        manifest = _write_matrix_from_adata(manifest, adata, slot=final_matrix_slot, bundle_dir=bundle_dir, subdir='final')         
        
+    if write_obsms:
+        print("Writing obsms to file")
+        obsms = adata.obsm.keys() if obsms[0] == 'all' else obsms
+
+        for obsm in obsms:
+            print(f"Writing {obsm}")
+            manifest = _write_obsm_from_adata(manifest, adata, obsm_name=obsm, bundle_dir=bundle_dir, atlas_style= atlas_style)
+
+    # Write the final file manifest
+
     _write_file_manifest(bundle_dir, manifest) 
+
+# Make filename and parameterisation from obsm names
+
+def _write_obsm_from_adata(manifest, adata, obsm_name, bundle_dir, atlas_style = True):
+
+    obsm_paramstring = obsm_name.replace('X_', '')
+    filename = f"{obsm_paramstring}.tsv"
+    
+    description='embeddings'
+    for embedding_type in [ 'umap', 'pca', 'tsne' ]:
+        if embedding_type in obsm_paramstring:
+            description=f'{embedding_type}_{description}'
+            obsm_paramstring=re.sub(r"_?%s_?" % embedding_type, '', obsm_paramstring)
+            break 
+  
+    # If following Atlas conventions, we can assume .obsm slots like
+    # X_umap_neighbors_n_neighbors_20, which after above processing should now
+    # be like neighbors_n_neighbors_20
+
+    if atlas_style:
+        parameterisation = obsm_paramstring.split('_')[-1]
+    else:
+        parameterisation = obsm_paramstring
+    
+    ss.obj_utils.write_embedding(adata, key=obsm_name, embed_fn=f"{bundle_dir}/{filename}")
+
+    manifest = _set_manifest_value(manifest, description, filename, parameterisation)
+    
+    return manifest
+
 
 def _read_file_manifest(bundle_dir):
     manifest_file=f"{bundle_dir}/MANIFEST"
-    manifest={}
+    manifest=OrderedDict()
 
     if os.path.isfile(manifest_file):
         with open(manifest_file) as fp:
             header=fp.readline()
             for line in fp:
-                line_parts=line.split("\t")
-                manifest = _set_manifest_value(manifest, line_parts[0], line_parts[2], line_parts[1])
+                line_parts=line.rstrip().split("\t")
+                manifest = _set_manifest_value(manifest, line_parts[0], line_parts[1], line_parts[2])
             
     return manifest
 
 def _write_file_manifest(bundle_dir, manifest):
     manifest_file=f"{bundle_dir}/MANIFEST"
 
-    with open(manifest_file, 'a') as fh:
+    with open(manifest_file, 'w') as fh:
         fh.write('Description\tFile\tParameterisation\n')
 
         for description, v in manifest.items():
@@ -68,8 +122,9 @@ def _write_file_manifest(bundle_dir, manifest):
 
 def _set_manifest_value(manifest, description, filename, parameterisation):
     if description not in manifest:
-        manifest[description] = {}
-        manifest[description][parameterisation] = filename
+        manifest[description] = OrderedDict()
+    
+    manifest[description][parameterisation] = filename
 
     return manifest
 
@@ -87,7 +142,7 @@ def _write_matrix_from_adata(manifest, adata, slot, bundle_dir, subdir):
 
     pathlib.Path(bundle_dir, subdir).mkdir(parents=True, exist_ok=True)    
     #ss.cmd_utils.write_mtx(adata, fname_prefix = '%s/%s/' % (bundle_dir, filename), use_raw=use_raw, use_layer=layer)
-    write_mtx(adata, fname_prefix = '%s/%s/' % (bundle_dir, subdir), use_raw=use_raw, use_layer=layer)
+    write_mtx(adata, fname_prefix = f"{bundle_dir}/{subdir}/", use_raw=use_raw, use_layer=layer)
     
     for filename in [ 'matrix.mtx', 'barcodes.tsv', 'genes.tsv' ]:
         subfile=f"{subdir}/{filename}" 
@@ -95,10 +150,10 @@ def _write_matrix_from_adata(manifest, adata, slot, bundle_dir, subdir):
         with open(filepath, 'rb') as f_in, gzip.open("%s.gz" % filepath, 'wb') as f_out:
             f_out.writelines(f_in)
         os.remove(filepath)
-
-    manifest = _set_manifest_value(manifest, 'mtx_matrix_content', f"{subdir}/matrix.mtx.gz", 'raw')
-    manifest = _set_manifest_value(manifest, 'mtx_matrix_cols', f"{subdir}/barcodes.tsv.gz", 'raw')
-    manifest = _set_manifest_value(manifest, 'mtx_matrix_rows', f"{subdir}/genes.mtx.gz", 'raw')
+    
+    manifest = _set_manifest_value(manifest, 'mtx_matrix_content', f"{subdir}/matrix.mtx.gz", subdir)
+    manifest = _set_manifest_value(manifest, 'mtx_matrix_cols', f"{subdir}/barcodes.tsv.gz", subdir)
+    manifest = _set_manifest_value(manifest, 'mtx_matrix_rows', f"{subdir}/genes.mtx.gz", subdir)
 
     return manifest
 

--- a/bin/bundle_from_anndata.py
+++ b/bin/bundle_from_anndata.py
@@ -37,8 +37,9 @@ import re
 @click.option('--max-rank-for-stats', type=click.INT, default=4, help='For how many top marker genes should stats (mean, median expression) be output?')
 @click.option('--atlas-style', default='run', help='Assume the tight conventions from SCXA, e.g. on .obsm slot naming')
 @click.option('--gene-name-field', default='gene_name', help='Field in .var where gene name (symbol) is stored.')
+@click.option('--write-anndata/--no--write--anndata', default=True, is_flag=True, help='Write the annData file itself to the bundle?')
 
-def create_bundle(anndata_file, bundle_dir, droplet=False, run_obs='run', exp_desc=None, raw_matrix_slot=None, filtered_matrix_slot=None, normalised_matrix_slot=None, final_matrix_slot=None, write_obsms=True, obsms=None, write_clusters = True, clusters = None, clusters_field_pattern = 'louvain', default_clustering = None, write_markers = True, marker_clusterings=None, metadata_marker_fields=None, write_marker_stats = True, marker_stats_layers=None, max_rank_for_stats=4,  atlas_style=True, gene_name_field='gene_name'):
+def create_bundle(anndata_file, bundle_dir, droplet=False, run_obs='run', exp_desc=None, raw_matrix_slot=None, filtered_matrix_slot=None, normalised_matrix_slot=None, final_matrix_slot=None, write_obsms=True, obsms=None, write_clusters = True, clusters = None, clusters_field_pattern = 'louvain', default_clustering = None, write_markers = True, marker_clusterings=None, metadata_marker_fields=None, write_marker_stats = True, marker_stats_layers=None, max_rank_for_stats=4,  atlas_style=True, gene_name_field='gene_name', write_anndata = True):
     """Build a bundle directory compatible with Single Cell Expression Atlas (SCXA) build proceseses
    
     \b 
@@ -106,6 +107,12 @@ def create_bundle(anndata_file, bundle_dir, droplet=False, run_obs='run', exp_de
         print("Writing markers to file")
         manifest = _write_markers_from_adata(manifest, adata, clusters = clusters, marker_clusterings = marker_clusterings, metadata_marker_fields = metadata_marker_fields, bundle_dir = bundle_dir, atlas_style = atlas_style, max_rank_for_stats = max_rank_for_stats, marker_stats_layers = marker_stats_layers, write_marker_stats = write_marker_stats)       
  
+    if write_anndata:
+        print("Writing annData file to bundle")
+        adata_filename = os.path.basename(anndata_file)
+        adata.write(f"{bundle_dir}/{adata_filename}")
+        manifest = _set_manifest_value(manifest, 'project_file', adata_filename, '')
+
     # Write the final file manifest
 
     _write_file_manifest(bundle_dir, manifest) 

--- a/bin/bundle_from_anndata.py
+++ b/bin/bundle_from_anndata.py
@@ -1,86 +1,160 @@
 #!/usr/bin/env python
 
+import click
 from pathlib import Path
 import scanpy as sc
 import scanpy_scripts as ss
+import pathlib
+import pandas as pd
+import gzip
+import os
 
-# Arguments:
-# 
-# annData input
-# bundle output dir
+@click.command()
+@click.argument('anndata_file', type=click.Path(exists=True))
+@click.argument('bundle_dir', type=click.Path(dir_okay=True))
+@click.option('--droplet', default=False, help='Specify that this is a droplet experiment. There must be an obs parameter that can be used to differentiate cells from different runs.')
+@click.option('--runObs', default='run', help='The column in obs that differentiates cells from different runs. Will be used to separate run-wise and cell-wise metdata.')
+@click.option('--expDesc', default=None, help='Provide an experiment description file. If unspecified, the script will check for a slot called "experiment" in the .uns slot of the annData object, and use that to create a starting version of an IDF file.', type=click.Path(exists=True))
+@click.option('--rawMatrixSlot', default=None, help='Slot where the most raw and least filtered expression data are stored. This is usually in raw.X, other values will be interpreted as layers (in .raw if prefixed with "raw". annData requires that .raw.X and .X match in .obs, so even when stored in .raw this will have to be the matrix afer cell filtering, but should ideally not be gene-filtered.')
+@click.option('--filteredMatrixSlot', default=None, help='Layer name or "X", specifying storage location for gene-filtered matrix before transformations such as log transform, scaling etc.')
+@click.option('--normalisedMatrixSlot', default=None, help='Layer name or "X", specifiying storage location for normalised matrix.')
+@click.option('--finalMatrixSlot', default=None, help='Layer name or "X", specifiying storage location for the final matrix after processing. Will usually be in .X.')
 
+def create_bundle(anndata_file, bundle_dir, droplet=False, runobs='run', expdesc=None, rawmatrixslot=None, filteredmatrixslot=None, normalisedmatrixslot=None, finalmatrixslot=None):
+    """Build a bundle directory compatible with Single Cell Expression Atlas (SCXA) build proceseses
+   
+    \b 
+    anndata_file - A file of the annData hdf5 specification, with all necessary information for SCXA.
+    bundle_dir   - A directory in which to create the bundle.
+    """
 
+    adata = sc.read(anndata_file)
+    pathlib.Path(bundle_dir).mkdir(parents=True, exist_ok=True)    
 
-## Write matrices
-# Call MTX-writing code used in scanpy-scripts
-# Write .raw.X, .X and anything in layers, or as specified in .uns['atlas_bundle']['matrices']
-# Add lines to MANIFEST for each matrix
+    manifest=_read_file_manifest(bundle_dir)
 
+    if rawmatrixslot is not None:
+        print("Storing raw matrix")
+        manifest = _write_matrix_from_adata(manifest, adata, slot=rawmatrixslot, bundle_dir=bundle_dir, subdir='raw')        
 
-## Write dimension reductions
-# Write dimreds in same way as scanpy-scripts.
-# Write everythin in .obsm, or as specified in .uns['atlas_bundle']['dimension_reductions']
+    if filteredmatrixslot is not None:
+        print("Storing filtered matrix")
+        manifest = _write_matrix_from_adata(manifest, adata, slot=filteredmatrixslot, bundle_dir=bundle_dir, subdir='raw_filtered')        
+       
+    _write_file_manifest(bundle_dir, manifest) 
 
-# Write cell metadata 
-# Write everything in 
+def _read_file_manifest(bundle_dir):
+    manifest_file=f"{bundle_dir}/MANIFEST"
+    manifest={}
 
+    if os.path.isfile(manifest_file):
+        with open(manifest_file) as fp:
+            header=fp.readline()
+            for line in fp:
+                line_parts=line.split("\t")
+                manifest = _set_manifest_value(manifest, line_parts[0], line_parts[2], line_parts[1])
+            
+    return manifest
 
+def _write_file_manifest(bundle_dir, manifest):
+    manifest_file=f"{bundle_dir}/MANIFEST"
 
-# Have a 'prepare_for_atlas' function to take an annData object and record
-# which slots will be exported to Atlas.
+    with open(manifest_file, 'a') as fh:
+        fh.write('Description\tFile\tParameterisation\n')
 
-def prepare_for_atlas(
-    x='filtered_normalised', 
-    raw.x='raw', 
-    layers='filtered'):
+        for description, v in manifest.items():
+            for parameterisation, filename in v.items():
+                fh.write(f"{description}\t{filename}\t{parameterisation}\n")
 
+def _set_manifest_value(manifest, description, filename, parameterisation):
+    if description not in manifest:
+        manifest[description] = {}
+        manifest[description][parameterisation] = filename
 
-# Note which slots should be exported 
+    return manifest
 
-def tag_for_atlas(
-    adata=None,
-    type='matrix',
-    slot=None,
-    name=None,
-    use_raw=False,
-    file=None):
+def _write_matrix_from_adata(manifest, adata, slot, bundle_dir, subdir):
+    
+    layer = None
+    use_raw = False
 
-    adata.uns['scxa'][type][name] = {
-        'slot' = slot,
-        'use_raw' = use_raw,
-        'file' = file
-    }
+    if 'raw.' in slot:
+        use_raw=True
+        slot = slot.replace('raw.', '')
+    
+    if slot != 'X':
+        layer = slot
 
-def export_for_atlas(adata, dir = None):
+    pathlib.Path(bundle_dir, subdir).mkdir(parents=True, exist_ok=True)    
+    #ss.cmd_utils.write_mtx(adata, fname_prefix = '%s/%s/' % (bundle_dir, filename), use_raw=use_raw, use_layer=layer)
+    write_mtx(adata, fname_prefix = '%s/%s/' % (bundle_dir, subdir), use_raw=use_raw, use_layer=layer)
+    
+    for filename in [ 'matrix.mtx', 'barcodes.tsv', 'genes.tsv' ]:
+        subfile=f"{subdir}/{filename}" 
+        filepath=f"{bundle_dir}/{subfile}"
+        with open(filepath, 'rb') as f_in, gzip.open("%s.gz" % filepath, 'wb') as f_out:
+            f_out.writelines(f_in)
+        os.remove(filepath)
 
-    if dir is None:
-        raise ValueError('No output directory provided')
+    manifest = _set_manifest_value(manifest, 'mtx_matrix_content', f"{subdir}/matrix.mtx.gz", 'raw')
+    manifest = _set_manifest_value(manifest, 'mtx_matrix_cols', f"{subdir}/barcodes.tsv.gz", 'raw')
+    manifest = _set_manifest_value(manifest, 'mtx_matrix_rows', f"{subdir}/genes.mtx.gz", 'raw')
+
+    return manifest
+
+def write_mtx(adata, fname_prefix='', var=None, obs=None, use_raw=False, use_layer=None):
+    """Export AnnData object to mtx formt
+    * Parameters
+        + adata : AnnData
+        An AnnData object
+        + fname_prefix : str
+        Prefix of the exported files. If not empty and not ending with '/' or '_',
+        a '_' will be appended. Full names will be <fname_prefix>matrix.mtx,
+        <fname_prefix>genes.tsv, <fname_prefix>barcodes.tsv
+        + var : list
+        A list of column names to be exported to gene table
+        + obs : list
+        A list of column names to be exported to barcode/cell table
+    """
+    if fname_prefix and not (fname_prefix.endswith('/') or fname_prefix.endswith('_')):
+        fname_prefix = fname_prefix + '_'
+    if var is None:
+        var = []
+    if obs is None:
+        obs = []
+
+    import scipy.sparse as sp
+    if use_raw:
+        var_source = adata.raw.var
+        mat = sp.coo_matrix(adata.raw.X)
     else:
-        Path(dir).mkdir(parents=True, exist_ok=True)
+        var_source = adata.var
+        if use_layer is not None:
+            mat=sp.coo_matrix(adata.layers[use_layer])
+        else:
+            mat = sp.coo_matrix(adata.X)
 
-    if not 'scxa' in adata.uns:
-        raise ValueError('No manifest present for single-cell expression atlas export')
-
-    for slot_type in adata.uns['scxa']:
-        for name, manifest_entry in adata.uns[slot_type].items():
-        
-            if slot_type = 'matrix':
-                if manifest_entry['slot'] != 'X':
-                    layer = manifest_entry['slot']
-
-                ss.cmd_utils.write_mtx(adata, fname_prefix = '%s/%s/' % (dir, manifest_entry['file']), use_raw=manifest_entry['use_raw'], layer=layer)
-
-            if slot_type = 'obsm':
-                ss.obj_utils.write_embedding(adata, key=slot, embed_fn = '%s/%s' % (dir, manifest_entry['file']))
-                
-            if slot_type = 'obs':
-                ad.obs[['age', 'organism']]to_csv(embed_fn, sep=s, header=False, index=True)
-
-            if slot_type = 'var':
-
+    obs = list(set(obs) & set(adata.obs.columns))
+    var = list(set(var) & set(var_source.columns))
     
+    n_obs, n_var = mat.shape
+    n_entry = len(mat.data)
+    header = '%%MatrixMarket matrix coordinate real general\n%\n{} {} {}\n'.format(
+        n_var, n_obs, n_entry)
+    df = pd.DataFrame({'col': mat.col + 1, 'row': mat.row + 1, 'data': mat.data})
+    mtx_fname = fname_prefix + 'matrix.mtx'
+    gene_fname = fname_prefix + 'genes.tsv'
+    barcode_fname = fname_prefix + 'barcodes.tsv'
+    with open(mtx_fname, 'a') as fh:
+        fh.write(header)
+        df.to_csv(fh, sep=' ', header=False, index=False)
 
+    obs_df = adata.obs[obs].reset_index(level=0)
+    obs_df.to_csv(barcode_fname, sep='\t', header=False, index=False)
+    var_df = var_source[var].reset_index(level=0)
+    if not var:
+        var_df['gene'] = var_df['index']
+    var_df.to_csv(gene_fname, sep='\t', header=False, index=False)
 
-
-    
-    
+if __name__ == '__main__':
+    create_bundle()

--- a/bin/bundle_from_anndata.py
+++ b/bin/bundle_from_anndata.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+import scanpy as sc
+import scanpy_scripts as ss
+
+# Arguments:
+# 
+# annData input
+# bundle output dir
+
+
+
+## Write matrices
+# Call MTX-writing code used in scanpy-scripts
+# Write .raw.X, .X and anything in layers, or as specified in .uns['atlas_bundle']['matrices']
+# Add lines to MANIFEST for each matrix
+
+
+## Write dimension reductions
+# Write dimreds in same way as scanpy-scripts.
+# Write everythin in .obsm, or as specified in .uns['atlas_bundle']['dimension_reductions']
+
+# Write cell metadata 
+# Write everything in 
+
+
+
+# Have a 'prepare_for_atlas' function to take an annData object and record
+# which slots will be exported to Atlas.
+
+def prepare_for_atlas(
+    x='filtered_normalised', 
+    raw.x='raw', 
+    layers='filtered'):
+
+
+# Note which slots should be exported 
+
+def tag_for_atlas(
+    adata=None,
+    type='matrix',
+    slot=None,
+    name=None,
+    use_raw=False,
+    file=None):
+
+    adata.uns['scxa'][type][name] = {
+        'slot' = slot,
+        'use_raw' = use_raw,
+        'file' = file
+    }
+
+def export_for_atlas(adata, dir = None):
+
+    if dir is None:
+        raise ValueError('No output directory provided')
+    else:
+        Path(dir).mkdir(parents=True, exist_ok=True)
+
+    if not 'scxa' in adata.uns:
+        raise ValueError('No manifest present for single-cell expression atlas export')
+
+    for slot_type in adata.uns['scxa']:
+        for name, manifest_entry in adata.uns[slot_type].items():
+        
+            if slot_type = 'matrix':
+                if manifest_entry['slot'] != 'X':
+                    layer = manifest_entry['slot']
+
+                ss.cmd_utils.write_mtx(adata, fname_prefix = '%s/%s/' % (dir, manifest_entry['file']), use_raw=manifest_entry['use_raw'], layer=layer)
+
+            if slot_type = 'obsm':
+                ss.obj_utils.write_embedding(adata, key=slot, embed_fn = '%s/%s' % (dir, manifest_entry['file']))
+                
+            if slot_type = 'obs':
+                ad.obs[['age', 'organism']]to_csv(embed_fn, sep=s, header=False, index=True)
+
+            if slot_type = 'var':
+
+    
+
+
+
+    
+    


### PR DESCRIPTION
So far done writing of:

 - matrices 
 - .obsm (dimension reductions)
 - clusters
 - marker
 - marker statistics (mean and median expression in clusters for marker genes). This was actually quite a bit simpler than the [R script ](https://github.com/ebi-gene-expression-group/scxa-bundle-workflow/blob/develop/bin/makeMarkerStats.R)we currently use. 
 - project file
 - Cell metadata, proto-SDRF and cells.txt from .obs to a mage-tab folder as the basis for curation.
 - Gene metadata file output from .var.

To do:

 - Software report
 - Pass-through of reference files- GTF, cDNA (maybe not essential for external users, but useful for us)
 - Pass-through of 'totally raw' MTX before cell filtering (again, possibly just for us)
 - Config from YAML

All outputs are paired with entries in a manifest.

I think this code will be useful in simplifying our processes as well as for external submitters, we can write more directly from the output anndata ourselves, rather than requiring a large number of separate file outputs from the Galaxy workflow.

The write_mtx() function is duplicated from scanpy_scripts, and will be used from there once a bugfix is released.