### PR TITLE
Compress MTX files directly

### DIFF
--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -494,16 +494,8 @@ def write_matrix_from_adata(
         use_raw=use_raw,
         use_layer=layer,
         var=[gene_name_field],
+        compression={"method": "gzip"}
     )
-
-    for filename in ["matrix.mtx", "barcodes.tsv", "genes.tsv"]:
-        subfile = f"{subdir}/{filename}"
-        filepath = f"{bundle_dir}/{subfile}"
-        with open(filepath, "rb") as f_in, gzip.open(
-            "%s.gz" % filepath, "wb"
-        ) as f_out:
-            f_out.writelines(f_in)
-        os.remove(filepath)
 
     manifest = set_manifest_value(
         manifest, "mtx_matrix_content", f"{subdir}/matrix.mtx.gz", subdir

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ scripts =
 install_requires =
     cmake<3.20
     scanpy>1.1.2
-    scanpy-scripts
+    scanpy-scripts>1.1.3
     PyYAML
     click
     jsonschema


### PR DESCRIPTION
This PR leverages the change made in https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/112 to output mtx files directly to compressed forms when producing the SCXA analysis bundle, without having to parse and compress after the fact (which was quite time consuming).