### PR TITLE
Make sure we reverse any log transform for SCXA import

### DIFF
--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -507,7 +507,7 @@ def scale_matrix_in_anndata(
     >>> print(adata.layers['normalised'][1, 2])
     7.3389006
     >>> # Scale up to per 10M
-    >>> scale_matrix_in_anndata(adata, 'normalised', 10000000)
+    >>> scale_matrix_in_anndata(adata, slot = 'normalised', scale = 10000000)
     >>> print(adata.layers['normalised'][1, 2])
     73.38901
     """


### PR DESCRIPTION
SCXA expects untransformed expression values for the matrix it loads to DB. Assume a Scanpy log1p() transformation and reverse it, prior to scaling and writing off files for loading to the DB.