### PR TITLE
Bump atlas-expeiriment-metadata version used in Snakemake workflow

### DIFF
--- a/atlas_anndata/snakemake/cell_metadata_from_magetab/workflow/envs/atlas-experiment-metadata.yml
+++ b/atlas_anndata/snakemake/cell_metadata_from_magetab/workflow/envs/atlas-experiment-metadata.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
   - ebi-gene-expression-group
 dependencies:
-  - atlas-experiment-metadata=0.1.2
+  - atlas-experiment-metadata>=0.1.5


### PR DESCRIPTION
New-style cell type fields weren't getting transferred from curation to the updated annData object. This was because we were using the last packaged version of [atlas-experiment-metadata](https://github.com/ebi-gene-expression-group/experiment_metadata), which was old and didn't contain recent fixes related to cell type field naming (we've mostly been using this via atlas-prod rather than the conda package).

The fix was to [make a new release](https://github.com/ebi-gene-expression-group/experiment_metadata/releases/tag/v0.1.5) and bump the version used here.  