### PR TITLE
Write less matrices

### DIFF
--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -268,6 +268,7 @@ def make_bundle_from_anndata(
     scxa_db_scale=1000000,
     atlas_style=False,
     default_clustering=None,
+    write_matrices=False,
     **kwargs,
 ):
 
@@ -277,7 +278,7 @@ def make_bundle_from_anndata(
     >>> shutil.rmtree(exp_name, ignore_errors=True)
     >>> shutil.copytree(f"{example_bundle_dir}/{exp_name}", exp_name)
     'E-MTAB-6077'
-    >>> make_bundle_from_anndata(exp_name = exp_name, step = 'final') # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> make_bundle_from_anndata(exp_name = exp_name, step = 'final', write_matrices = True) # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE
     Validating config against .../config_schema.yaml
     Config YAML file successfully validated
     Now checking config against anndata file
@@ -356,6 +357,7 @@ def make_bundle_from_anndata(
             config=config,
         )
 
+    if step == "final" or write_matrices:
         write_matrices_from_adata(
             manifest=manifest,
             bundle_dir=bundle_subdir,

--- a/bin/make_bundle_from_anndata
+++ b/bin/make_bundle_from_anndata
@@ -144,6 +144,17 @@ from scanpy_scripts.click_utils import CommaSeparatedText
         " cell-wise sum in the given matrix."
     ),
 )
+@click.option(
+    "--write-matrices",
+    default=False,
+    is_flag=True,
+    help=(
+        "Write matrices to the bundle at non-final steps? This must"
+        " necessarily happen in the final matrix bundling, but it's a slow"
+        " process so is not normally done at the previous steps. Activate this"
+        " flag to override that behaviour and write regardless."
+    ),
+)
 def make_bundle(step, *args, **kwargs):
 
     """Build a bundle directory compatible with Single Cell Expression Atlas


### PR DESCRIPTION
Writing the matrices takes forever with big annData objects. Let's not do it unless we have to (or the user asks for it explicitly).