### PR TITLE
Make summary stats calculation for efficient

### DIFF
--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1080,10 +1080,15 @@ def write_markers_from_adata(
     ...    max_rank_for_stats=5)
     Writing markers and statistics
     Calculating summary stats for normalised matrix, cell groups defined by ['louvain_resolution_0.7', 'louvain_resolution_1.0']
+    ..louvain_resolution_0.7
+    ..louvain_resolution_1.0
+    Completed summary stats calculation
+    Compiling summaries for cell groupings
     ..calculating summary for cell grouping louvain_resolution_0.7
     ..limiting stats report to top 5 differential genes
     ..calculating summary for cell grouping louvain_resolution_1.0
     ..limiting stats report to top 5 differential genes
+    Done compiling summaries for cell groupings
     >>> shutil.rmtree(test_bundle, ignore_errors=True)
     """
 
@@ -1474,6 +1479,22 @@ def calculate_summary_stats(adata, obs, matrix="normalised"):
     Calculating summary stats for normalised matrix, cell groups defined by ['louvain_resolution_0.7']
     ..louvain_resolution_0.7
     Completed summary stats calculation
+    >>> adata.varm['mean_normalised_louvain_resolution_0.7'] # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE 
+                                 0           1
+    ENSDARG00000000001    5.210635    4.868471
+    ENSDARG00000000002    5.107658    0.254911
+    ENSDARG00000000018  240.056006  319.279625
+    ENSDARG00000000019   34.447536    9.438827
+    ENSDARG00000000068   33.625522    1.097745
+    ...
+    >>> adata.varm['median_normalised_louvain_resolution_0.7'] # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE 
+                             0           1
+    ENSDARG00000000001    0.000000    0.000000
+    ENSDARG00000000002    0.000000    0.000000
+    ENSDARG00000000018  141.642776  159.815002
+    ENSDARG00000000019    0.000000    0.000000
+    ENSDARG00000000068    0.000000    0.000000
+    ...
     """
 
     print(

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1507,7 +1507,7 @@ def calculate_summary_stats(adata, obs, matrix="normalised"):
             return matrix.mean(axis=0, dtype=np.float64)
         else:
             return skl.utils.sparsefuncs.csc_median_axis_0(
-                sp.sparse.csc_matrix(matrix)
+                sp.sparse.csc_matrix(matrix, dtype=np.float64)
             )
 
     for ob in obs:

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1213,6 +1213,8 @@ def make_markers_summary(
     ...    [ marker_grouping ],
     ...    matrix='normalised')
     Calculating summary stats for normalised matrix, cell groups defined by ['louvain_resolution_0.7']
+    ..louvain_resolution_0.7
+    Completed summary stats calculation
     >>> make_markers_summary(
     ...    adata,
     ...    egconfig["matrices"]["load_to_scxa_db"],

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1516,6 +1516,7 @@ def calculate_summary_stats(adata, obs, matrix="normalised"):
                     for group in adata.obs[ob].cat.categories
                 ],
                 columns=adata.var_names,
+                index=adata.obs[ob].cat.categories,
             ).transpose()
 
     print("Completed summary stats calculation")

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1170,7 +1170,7 @@ def write_markers_from_adata(
                 matrix=matrix_for_stats,
             )
 
-            print(f"Compiling summaries for cell groupings")
+            print("Compiling summaries for cell groupings")
             marker_summary = pd.concat(
                 [
                     make_markers_summary(
@@ -1184,7 +1184,7 @@ def write_markers_from_adata(
                     for cell_grouping, de_table in de_tables.items()
                 ]
             )
-            print(f"Done compiling summaries for cell groupings")
+            print("Done compiling summaries for cell groupings")
             statsfile = f"{matrix_for_stats_name}_stats.csv"
 
             marker_summary.to_csv(

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1479,7 +1479,7 @@ def calculate_summary_stats(adata, obs, matrix="normalised"):
     Calculating summary stats for normalised matrix, cell groups defined by ['louvain_resolution_0.7']
     ..louvain_resolution_0.7
     Completed summary stats calculation
-    >>> adata.varm['mean_normalised_louvain_resolution_0.7'] # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE 
+    >>> adata.varm['mean_normalised_louvain_resolution_0.7'] # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE
                                  0           1
     ENSDARG00000000001    5.210635    4.868471
     ENSDARG00000000002    5.107658    0.254911
@@ -1487,7 +1487,7 @@ def calculate_summary_stats(adata, obs, matrix="normalised"):
     ENSDARG00000000019   34.447536    9.438827
     ENSDARG00000000068   33.625522    1.097745
     ...
-    >>> adata.varm['median_normalised_louvain_resolution_0.7'] # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE 
+    >>> adata.varm['median_normalised_louvain_resolution_0.7'] # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE
                              0           1
     ENSDARG00000000001    0.000000    0.000000
     ENSDARG00000000002    0.000000    0.000000

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -309,10 +309,15 @@ def make_bundle_from_anndata(
     Writing obs (unsupervised clusterings)
     Writing markers and statistics
     Calculating summary stats for normalised matrix, cell groups defined by ['louvain_resolution_0.7', 'louvain_resolution_1.0']
+    ..louvain_resolution_0.7
+    ..louvain_resolution_1.0
+    Completed summary stats calculation
+    Compiling summaries for cell groupings
     ..calculating summary for cell grouping louvain_resolution_0.7
     ..limiting stats report to top 5 differential genes
     ..calculating summary for cell grouping louvain_resolution_1.0
     ..limiting stats report to top 5 differential genes
+    Done compiling summaries for cell groupings
     Writing dimension reductions
     .. Writing dimension reduction from slot: X_umap_neighbors_n_neighbors_3
     .. Writing dimension reduction from slot: X_umap_neighbors_n_neighbors_10
@@ -1165,6 +1170,7 @@ def write_markers_from_adata(
                 matrix=matrix_for_stats,
             )
 
+            print(f"Compiling summaries for cell groupings")
             marker_summary = pd.concat(
                 [
                     make_markers_summary(
@@ -1178,6 +1184,7 @@ def write_markers_from_adata(
                     for cell_grouping, de_table in de_tables.items()
                 ]
             )
+            print(f"Done compiling summaries for cell groupings")
             statsfile = f"{matrix_for_stats_name}_stats.csv"
 
             marker_summary.to_csv(
@@ -1463,6 +1470,8 @@ def calculate_summary_stats(adata, obs, matrix="normalised"):
     ...    [ marker_grouping ],
     ...    matrix='normalised')
     Calculating summary stats for normalised matrix, cell groups defined by ['louvain_resolution_0.7']
+    ..louvain_resolution_0.7
+    Completed summary stats calculation
     """
 
     print(


### PR DESCRIPTION
This PR updates the calculation of summary stats by cell group (mean, median) to not use Scanpy's get.obs_df(). That function essentially flattens all the expression from sparse matrices to a dense format in a Pandas dataframe which on reflection was clearly not a great plan (it was only intended for use with a handful of marker genes, not all genes as we need here).

Instead the stats are calculated directly on matrices from slices of the annData object. On a small test dataset of 10k cells this took memory usage down from 6.7Gb to about 600Mb.

This issue was preventing successful analysis of large datasets such as the HLCA.