### PR TITLE
Simplify setup to faciliate a conda wrapper

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ scripts =
     bin/validate_anndata_with_config
     bin/make_bundle_from_anndata
 install_requires =
-    scanpy-scripts>1.1.3
+    scanpy-scripts>1.1.5
     PyYAML
     click
     jsonschema

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = atlas_anndata
+python_requires = '<3.9'
 version = 0.1.0
 author = Jonathan Manning
 author_email = jmanning@ebi.ac.uk
@@ -21,8 +22,6 @@ scripts =
     bin/validate_anndata_with_config
     bin/make_bundle_from_anndata
 install_requires =
-    cmake<3.20
-    scanpy>1.1.2
     scanpy-scripts>1.1.3
     PyYAML
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = atlas_anndata
-python_requires = '<3.9'
 version = 0.1.0
 author = Jonathan Manning
 author_email = jmanning@ebi.ac.uk
@@ -27,7 +26,7 @@ install_requires =
     click
     jsonschema
     snakemake
-python_requiresi = ">=3.6"
+python_requires = >= 3.6, <3.9
 
 [flake8]
 ignore = E203, E266, E501, W503, F403, F401


### PR DESCRIPTION
This PR removes cmake as a dependency which is unnecessary (following removal of multicore-tsne as a dependency in https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/115) and makes the Conda wrapper difficult.

It also specifies a python version since some deps have issues with Py > 3.8.