### PR TITLE
More efficiency measures for marker stats table calc

### DIFF
--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1255,23 +1255,21 @@ def make_markers_summary(
     """
 
     print(f"..calculating summary for cell grouping {marker_grouping}")
-    if not max_rank:
-        max_rank = de_table["rank"].max()
-    else:
+    if max_rank:
         print(f"..limiting stats report to top {max_rank} differential genes")
+        de_table = de_table[de_table["rank"] <= (max_rank - 1)]
 
     markers_summary = (
-        de_table[de_table["rank"] <= (max_rank - 1)]
-        .drop(["ref", "scores", "logfoldchanges", "pvals"], axis=1)
+        de_table.drop(["ref", "scores", "logfoldchanges", "pvals"], axis=1)
         .merge(
             pd.concat(
                 [
-                    adata.varm[f"mean_{layer}_{marker_grouping}"].melt(
-                        ignore_index=False
-                    ),
-                    adata.varm[f"median_{layer}_{marker_grouping}"].melt(
-                        ignore_index=False
-                    ),
+                    adata.varm[f"mean_{layer}_{marker_grouping}"]
+                    .loc[de_table["genes"]]
+                    .melt(ignore_index=False),
+                    adata.varm[f"median_{layer}_{marker_grouping}"]
+                    .loc[de_table["genes"]]
+                    .melt(ignore_index=False),
                 ],
                 axis=1,
             )

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1256,7 +1256,7 @@ def make_markers_summary(
 
     print(f"..calculating summary for cell grouping {marker_grouping}")
     if not max_rank:
-        max_rank = markers_summary["rank"].max()
+        max_rank = de_table["rank"].max()
     else:
         print(f"..limiting stats report to top {max_rank} differential genes")
 


### PR DESCRIPTION
This PR attempts to address failings in resource usage that prevail even after https://github.com/ebi-gene-expression-group/atlas-anndata/pull/25. 

The issue is caused by the merger of a marker stats frame with the potentially rather large summary statistics data frames. In the current code, summary statistics are merged to marker statistics (p values etc), and then subset to the top-ranking marker genes. It is clearly better to subset the marker genes before the merger with summary stats, this should much improve memory usage. **Edit: confirmed, this has very significantly reduced the memory to within reasonable limits.**

There is also a fix here to apply a missing log transform to input matrices that require it, before the marker calculation.
