### PR TITLE
Fix a sample_field reference in non-droplet context

### DIFF
--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -395,7 +395,7 @@ def make_bundle_from_anndata(
             atlas_style=atlas_style,
             droplet=config["droplet"],
             default_clustering=default_clustering,
-            sample_field=config["cell_meta"]["sample_field"],
+            sample_field=config["cell_meta"].get("sample_field"),
         )
 
         current_meta_slots = [


### PR DESCRIPTION
This tiny fix addresses an issue reported by @YalanBi caused by use of `sample_field` in a non-droplet experiment. Use of `.get()` (returning `None` in this case) should solve the problem (the droplet status is used properly in the called function).