### PR TITLE
Don't use raw matrix for marker calculation unless appropriate, use load_to_scxa_db matrix by default.

### DIFF
--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -408,7 +408,7 @@ def get_markers_table(adata, marker_grouping):
     return de_table
 
 
-def calculate_markers(adata, config, matrix="X", use_raw=None):
+def calculate_markers(adata, config, matrix=None, use_raw=None):
 
     """Calculate any missing marker sets for .obs columns tagged in the config
     has needing them, but which don't currently have them
@@ -421,6 +421,15 @@ def calculate_markers(adata, config, matrix="X", use_raw=None):
     >>> calculate_markers(adata, egconfig, matrix = matrix_for_markers, use_raw = False)
     Marker statistics not currently available for louvain_resolution_0.7, recalculating with Scanpy...
     """
+
+    # Unless a specific override is supplied, use the 'load_to_scxa_db' matrix
+    # where provided, or fall back to .X.
+
+    if matrix is None:
+        if "load_to_scxa_db" in config["matrices"]:
+            matrix = config["matrices"]["load_to_scxa_db"]
+        else:
+            matrix = "X"
 
     marker_groupings = [
         x["slot"] for x in config["cell_meta"]["entries"] if x["markers"]
@@ -451,7 +460,7 @@ def calculate_markers(adata, config, matrix="X", use_raw=None):
         elif matrix != "X":
             layer = matrix
 
-        if matrix != 'raw.X':
+        if matrix != "raw.X":
             use_raw = False
 
         # rank_genes_groups "Expects logarithmized data.", so apply that transform if required

--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -450,6 +450,8 @@ def calculate_markers(adata, config, matrix="X", use_raw=None):
             raise Exception(errmsg)
         elif matrix != "X":
             layer = matrix
+
+        if matrix != 'raw.X':
             use_raw = False
 
         # rank_genes_groups "Expects logarithmized data.", so apply that transform if required

--- a/bin/make_bundle_from_anndata
+++ b/bin/make_bundle_from_anndata
@@ -88,13 +88,15 @@ from scanpy_scripts.click_utils import CommaSeparatedText
 @click.option(
     "--matrix-for-markers",
     required=True,
-    default="X",
+    default=None,
     help=(
         "Where cell groups in the configuration file have been flagged with"
         " markers, which matrix should be used? Can be X, or an entry in"
         " .layers(). The matrix must be appropriate for Scanpy's"
         " tl.rank_genes_groups() method, usually meaning filtered, normalised"
-        " and log transformed, but without additional scaling."
+        " and log transformed, but without additional scaling. If not set, and"
+        " 'load_to_scxa_db' matrix is indicated in the configuration, that"
+        " matrix will be used, otherwise reverts to .X."
     ),
 )
 @click.option(

--- a/bin/make_bundle_from_anndata
+++ b/bin/make_bundle_from_anndata
@@ -87,7 +87,7 @@ from scanpy_scripts.click_utils import CommaSeparatedText
 )
 @click.option(
     "--matrix-for-markers",
-    required=True,
+    required=False,
     default=None,
     help=(
         "Where cell groups in the configuration file have been flagged with"


### PR DESCRIPTION
This PR:

- Corrects a bug whereby 'None' was supplied to `use_raw` for rank_genes_groups(), allowing scanpy to use .raw where present. 
- Uses any matrix flagged as 'load_to_scxa_db matrix' for marker detection by default.