### PR TITLE
Remove single groups from marker detection

### DIFF
--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -475,9 +475,18 @@ def calculate_markers(adata, config, matrix=None, use_raw=None):
                     " recalculating with Scanpy..."
                 )
                 try:
+                    groups = "all"
+                    if adata.obs[mg].value_counts().min() < 2:
+                        groups = list(
+                            adata.obs[mg]
+                            .value_counts()
+                            .index[adata.obs[mg].value_counts() > 1]
+                        )
+
                     sc.tl.rank_genes_groups(
                         adata,
                         mg,
+                        groups=groups,
                         method="wilcoxon",
                         layer=layer,
                         key_added="markers_" + mg,


### PR DESCRIPTION
This PR fixes the error:

```
ValueError: Could not calculate statistics for groups op since they only contain one sample.
```

... which was occurring when we had singlet groups in metadata columns needing markers. Where singlet groups are found we now explicitly flag non-single groups for marker detection.