### PR TITLE
Sanitise fields to be used for marker detection to avoid HDF5 write errors

### DIFF
--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -52,11 +52,22 @@ def update_anndata(adata, config, matrix_for_markers=None, use_raw=None):
     ):
         adata.var.set_index(config["gene_meta"]["id_field"], inplace=True)
 
-    # Calcluate markers where necessary
+    # Find out which cell groupings have been flagged for markers
+
     marker_groupings = [
         x["slot"] for x in config["cell_meta"]["entries"] if x["markers"]
     ]
+
+    # Calcluate markers where necessary
+
     if len(marker_groupings) > 0:
+
+        # Do some limited sanitation due to problems caused by slashes in fields
+        # used for marker detection
+
+        for mg in marker_groupings:
+            adata.obs[mg] = pd.Categorical(adata.obs[mg].str.replace("/", " "))
+
         calculate_markers(
             adata=adata,
             config=config,


### PR DESCRIPTION
This PR was prompted by receiving an error like: 

```
anndata._io.utils.AnnDataReadError: Above error raised while reading key '/varm/mean_X_authors_cell_type_-_ontology_labels' of type <class 'h5py._hl.group.Group'> from /.
```

This is because of the way we store summary statistics for cell groups. Where those cell groups contain a slash, this has caused trouble writing the HDF5 file (in fact it completely corrupted it). We must therefore remove slashes from cell group names prior to marker gene calculation and associated summary stats calculation.