### PR TITLE
alternative sanitation

### DIFF
--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -52,22 +52,11 @@ def update_anndata(adata, config, matrix_for_markers=None, use_raw=None):
     ):
         adata.var.set_index(config["gene_meta"]["id_field"], inplace=True)
 
-    # Find out which cell groupings have been flagged for markers
-
+    # Calcluate markers where necessary
     marker_groupings = [
         x["slot"] for x in config["cell_meta"]["entries"] if x["markers"]
     ]
-
-    # Calcluate markers where necessary
-
     if len(marker_groupings) > 0:
-
-        # Do some limited sanitation due to problems caused by slashes in fields
-        # used for marker detection
-
-        for mg in marker_groupings:
-            adata.obs[mg] = pd.Categorical(adata.obs[mg].str.replace("/", " "))
-
         calculate_markers(
             adata=adata,
             config=config,

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -483,6 +483,15 @@ def make_bundle_from_anndata(
 
     # Write the anndata file back to the bundle
 
+    # Remove summary statistics before writing the file. This will keep the
+    # anndata file smaller, and avoid problems we had writing stats relating to
+    # cell groups with '/'.
+
+    for stat_slot in [
+        x for x in adata.varm.keys() if "mean" in x or "median" in x
+    ]:
+        del adata.varm[stat_slot]
+
     print("Writing annData file")
     adata_filename = f"{exp_name}.project.h5ad"
     adata.write(f"{bundle_subdir}/{adata_filename}")


### PR DESCRIPTION
This PR addresses a problem caused by https://github.com/ebi-gene-expression-group/atlas-anndata/pull/34.

Sanitising the columns helped writing the anndata object, but created problems in matching marker files with condensed SDRFs downstream.

This just removes the problem data structures for writing (in `.varm`). They were probably taking up space unnecessarily anyway, but in any case I lack the time for a more thorough solution. 