### PR TITLE
Fix unsupervised cluster renumbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,28 @@ For all sections, check [the example](atlas_anndata/data/bundles/E-MTAB-6077/ann
 
 You would fill the 'name' field here with something more descriptive for the matrix.
 
+### Mark cell metadata fields for marker detection
+
+Any categorical field can be used for marker detection (where appropriate matrices are available). This involves flipping the 'marker' status on a field annotation, e.g. changing:
+
+```
+  - default: false
+    kind: clustering
+    markers: true
+    parameters: {}
+    slot: leiden
+```
+
+... to 
+
+```
+  - default: false
+    kind: clustering
+    markers: false
+    parameters: {}
+    slot: leiden
+```
+
 #### Validate config YAML
 
 Having edited the config YAML, you should validate it against a schema we provide and the annData file itself. We can use this mechanism to ensure that inputs match the expectations of Single Cell Expression Atlas. 

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -35,6 +35,7 @@ from .util import (
     clusterings_to_ks,
     check_bundle_init,
     remove_empty_dirs,
+    renumber_clusters,
 )
 
 from .anndata_ops import (
@@ -705,7 +706,7 @@ def write_clusters_from_adata(manifest, bundle_dir, adata, config):
 
     # Create a DataFrame for cluster outputs
 
-    clusters = adata.obs[cluster_obs].T
+    clusters = pd.DataFrame(adata.obs[cluster_obs]).apply(renumber_clusters).T
     clusters["K"] = [clustering_to_k[x] for x in cluster_obs]
     clusters["sel.K"] = default_cluster_obs
 
@@ -1145,7 +1146,7 @@ def write_markers_from_adata(
             # Reset cluster numbering to be from 1 if required
 
             if de_table["cluster"].min() == "0":
-                de_table["cluster"] = [int(x) + 1 for x in de_table["cluster"]]
+                de_table["cluster"] = renumber_clusters(de_table["cluster"])
 
         # Write marker table to tsv
 
@@ -1311,9 +1312,9 @@ def make_markers_summary(
             markers_summary["cluster_id"].str.isnumeric().all()
             and min([int(x) for x in markers_summary["cluster_id"]]) == 0
         ):
-            markers_summary["cluster_id"] = [
-                int(x) + 1 for x in markers_summary["cluster_id"]
-            ]
+            markers_summary["cluster_id"] = renumber_clusters(
+                markers_summary["cluster_id"]
+            )
     else:
         markers_summary["grouping_where_marker"] = marker_grouping
 

--- a/atlas_anndata/util.py
+++ b/atlas_anndata/util.py
@@ -374,3 +374,23 @@ def remove_empty_dirs(path, remove_root=False):
         if len(files) == 0 and remove_root:
             print(f"Removing empty folder: {path}")
             os.rmdir(path)
+
+
+def renumber_clusters(clusters):
+    """
+    Renumber an array of values to start from 1 instead of 0, conditional on
+    them alll being integers
+
+    >>> renumber_clusters(pd.Series(['0', '1', '2']))
+    [1, 2, 3]
+    >>> renumber_clusters(pd.Series(['1', '1', '2']))
+    0    1
+    1    1
+    2    2
+    dtype: object
+    """
+
+    if clusters.str.isnumeric().all() and min([int(x) for x in clusters]) == 0:
+        return [int(x) + 1 for x in clusters]
+    else:
+        return clusters


### PR DESCRIPTION
This PR fixes an issue whereby cell groups from unsupervised clusters were not consistently renumbered between marker statistics and cell clusters outputs. A new routine does all the renumbering and is called everywhere.