### PR TITLE
Make sure parameter is a string when adding to manifest

### DIFF
--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1438,7 +1438,7 @@ def set_manifest_value(manifest, description, filename, parameterisation=""):
     if description not in manifest:
         manifest[description] = OrderedDict()
 
-    manifest[description][parameterisation] = filename
+    manifest[description][str(parameterisation)] = filename
 
     return manifest
 


### PR DESCRIPTION
This PR fixes an issue whereby the manifest would accumulated duplicate entries where it was initially populated from an existing bundle directory and subsequently modified. The initial read would create string parameters (e.g. '45' for a markers file), but then other operations might supply a number for the parameter (e.g. 45). This would lead to distinct entries in the file manifest python object which would appear as duplicates when the manifest was written (e.g. [here](https://github.com/ebi-gene-expression-group/atlas-anndata/blob/522277a4525558761737c23a8361718e7e4fe66c/atlas_anndata/funcs.py#L1159)).

The simple solution is just to make sure we store the parameter as a string.