### PR TITLE
Try to make sure altered object is readable

### DIFF
--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -40,6 +40,9 @@ def update_anndata(adata, config, matrix_for_markers=None, use_raw=None):
     >>> sc.pp.log1p(adata, layer = matrix_for_markers)
     >>> update_anndata(adata, egconfig, matrix_for_markers=matrix_for_markers, use_raw = False)
     Marker statistics not currently available for louvain_resolution_0.7, recalculating with Scanpy...
+    >>> # Make sure we haven't done anything that would make the object unreadable
+    >>> adata.write("foo.h5ad")
+    >>> adata = sc.read("foo.h5ad")
     """
 
     # Record the config in the object
@@ -50,7 +53,7 @@ def update_anndata(adata, config, matrix_for_markers=None, use_raw=None):
         config["gene_meta"]["id_field"] != "index"
         and MISSING not in config["gene_meta"]["id_field"]
     ):
-        adata.var.set_index(config["gene_meta"]["id_field"], inplace=True)
+        adata.var_names = adata.var[config["gene_meta"]["id_field"]]
 
     # Calcluate markers where necessary
     marker_groupings = [

--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -54,6 +54,7 @@ def update_anndata(adata, config, matrix_for_markers=None, use_raw=None):
         and MISSING not in config["gene_meta"]["id_field"]
     ):
         adata.var_names = adata.var[config["gene_meta"]["id_field"]]
+        adata.var.index.name = None
 
     # Calcluate markers where necessary
     marker_groupings = [


### PR DESCRIPTION
This PR addresses errors like:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/site-packages/scanpy/readwrite.py", line 112, in read
    return _read(
  File "/path/to/site-packages/scanpy/readwrite.py", line 713, in _read
    return read_h5ad(filename, backed=backed)
  File "/path/to/site-packages/anndata/_io/h5ad.py", line 437, in read_h5ad
    return AnnData(**d)
  File "/path/to/site-packages/anndata/_core/anndata.py", line 308, in __init__
    self._init_as_actual(
  File "/path/to/site-packages/anndata/_core/anndata.py", line 518, in _init_as_actual
    self._varm = AxisArrays(self, 1, vals=convert_to_dict(varm))
  File "/path/to/site-packages/anndata/_core/aligned_mapping.py", line 235, in __init__
    self.update(vals)
  File "/path/to/_collections_abc.py", line 832, in update
    self[key] = other[key]
  File "/path/to/site-packages/anndata/_core/aligned_mapping.py", line 151, in __setitem__
    value = self._validate_value(value, key)
  File "/path/to/site-packages/anndata/_core/aligned_mapping.py", line 212, in _validate_value
    raise ValueError(
ValueError: value.index does not match parent’s axis 1 names
```

I think the issue was re-indexing of `.var` when I should have been operating on the anndata object.