### PR TITLE
Fixes to ensure SCXA loading compatibility

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:
-          python-version: "3.9"
+          python-version: "3.8"
       # - name: flake8 Lint .py files
       #   uses: py-actions/flake8@v2
       #   with:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,20 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # - uses: psf/black@stable
+      #   with:
+      #     options: '--check --verbose --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:
           python-version: "3.9"
-      - name: flake8 Lint .py files
-        uses: py-actions/flake8@v2
-        with:
-          path: "."
-          args: '-vv'
-      - name: flake8 Lint scripts
-        uses: py-actions/flake8@v2
-        with:
-          path: "bin"
-          args: '--filename="*" -vv'
+      # - name: flake8 Lint .py files
+      #   uses: py-actions/flake8@v2
+      #   with:
+      #     path: "."
+      #     args: '-vv'
+      # - name: flake8 Lint scripts
+      #   uses: py-actions/flake8@v2
+      #   with:
+      #     path: "bin"
+      #     args: '--filename="*" -vv'
       - name: Install dependencies
         run: |
           pip install pytest

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-          options: '--check --verbose --preview --include="\.pyi?$|bin/*" .'
+          options: '--check --verbose --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@master
+      - uses: psf/black@main
         with:
           options: '--check --verbose --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@main
+      - uses: psf/black@stable
         with:
-          options: '--check --verbose --include="\.pyi?$|bin/*" .'
+          options: '--check --verbose --preview --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,9 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@stable
-        with:
-          options: '--check --verbose --preview --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,11 +9,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-          options: '--check --verbose --include="\.pyi?$|bin/*" .'
+          options: '--check --verbose --preview --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: flake8 Lint .py files
         uses: py-actions/flake8@v2
         with:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-          options: '--check --verbose --include="\.pyi?$|bin/*" .'
+          options: '--check --verbose --preview --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@stable
+      - uses: psf/black@master
         with:
-          options: '--check --verbose --preview --include="\.pyi?$|bin/*" .'
+          options: '--check --verbose --include="\.pyi?$|bin/*" .'
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Any categorical field can be used for marker detection (where appropriate matric
 ```
   - default: false
     kind: clustering
-    markers: true
+    markers: false
     parameters: {}
     slot: leiden
 ```
@@ -340,7 +340,7 @@ Any categorical field can be used for marker detection (where appropriate matric
 ```
   - default: false
     kind: clustering
-    markers: false
+    markers: true
     parameters: {}
     slot: leiden
 ```

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The config is likely to wrong in a number of ways, but its just a starting point
 
 ### 2: refine configuration for curation
 
-With the configuration file and unmoderated content available to us we can make some sensible decisions about some of those settings in the YAML file.
+With the configuration file and unmoderated content available to us, we can make some sensible decisions about some of those settings in the YAML file.
 
 #### Identify correct gene ID and gene name fields
 
@@ -283,20 +283,20 @@ make_bundle_from_anndata E-MTAB-6077 inject_magetab
 
 This will pull the curated metadata from the `scxa-metadata` repo, condense the SDRF (adding ontology terms) and re-generate cell-wise annotations that will be used to enrich the content of the annData file, with any new fields from curation added to `.obs`. It will also add configuration for those fields to the YAML.
 
-Not that `--conda-prefix` can be spedified here, and is a location conda environments will be stored for the workflow that does SDRF condensation etc.
+Not that `--conda-prefix` can be specified here, and is a location conda environments will be stored for the workflow that does SDRF condensation etc.
 
 ### 6. Finalise configuration
 
-We're almost ready to creat our final bundle, but we must first finalise all the configuration in `anndata-config.yaml` for the bundle.
+We're almost ready to create our final bundle, but we must first finalise all the configuration in `anndata-config.yaml` for the bundle.
 
 #### Flag curated fields
 
-Cell meta data from annData objects is a mixture of any input sample metadata provided by the author, plus annotations added over the course of analysis. The latter may not be appropriate for inclusion in the metadata in SCXA. Check the fields described in `cell_meta`, especially their kind ('curation', 'clustering', 'analysis'). Curated fields are those present before analysis, biological and technical info for cells and samples. Clustering is used to indicate the results of unsupervised cell clustering stored in .obs. Analysis is everthing else, comprising all other fields added to .obs during analysis.
+Cell metadata from annData objects is a mixture of any input sample metadata provided by the author, plus annotations added over the course of analysis. The latter may not be appropriate for inclusion in the metadata in SCXA. Check the fields described in `cell_meta`, especially their kind ('curation', 'clustering', 'analysis'). Curated fields are those present before analysis, biological and technical info for cells and samples. Clustering is used to indicate the results of unsupervised cell clustering stored in .obs. Analysis is everything else, comprising all other fields added to .obs during analysis.
 
 Most importantly: 
 
  - Flip `curation` to `analysis` for any field entry which should not ultimately form part of the SCXA experiment MAGE-TAB format metadata.
- - Ensure any fields corresponding to unsupervised clusterings are flagged correctly.
+ - Ensure any fields corresponding to unsupervised clustering are flagged correctly.
 
 #### Gather other missing info needed before final bundle creation
 

--- a/atlas_anndata/anndata_ops.py
+++ b/atlas_anndata/anndata_ops.py
@@ -461,7 +461,7 @@ def calculate_markers(adata, config, matrix=None, use_raw=None):
                 " transformations as required."
             )
             raise Exception(errmsg)
-        elif matrix != "X":
+        elif matrix != "X" and matrix != "raw.X":
             layer = matrix
 
         if matrix != "raw.X":

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1468,7 +1468,7 @@ def set_manifest_value(manifest, description, filename, parameterisation=""):
 
     >>> manifest = read_file_manifest(example_manifest)
     >>> set_manifest_value(
-    ...    manifest, "analysis_versions_file", f"foo.tsv")
+    ...    manifest, "analysis_versions_file", "foo.tsv")
     OrderedDict([('analysis_versions_file', OrderedDict([('', 'foo.tsv')]))])
     """
 

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -912,6 +912,7 @@ def write_gene_metadata(
         "n_cells",
         "highly_variable",
         "dispersion",
+        "std",
     ]
 
     nonmeta_cols = [

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -479,7 +479,7 @@ def make_bundle_from_anndata(
                 f"{bundle_subdir}/software.tsv", sep="\t", index=False
             )
             set_manifest_value(
-                manifest, "analysis_versions_file", "software.tsv"
+                manifest, "software_versions_file", "software.tsv"
             )
 
     # Write the anndata file back to the bundle

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -498,6 +498,8 @@ def make_bundle_from_anndata(
     ]:
         del adata.varm[stat_slot]
 
+    if 'scxa_config' in adata.uns.keys(): del adata.uns['scxa_config']
+
     print("Writing annData file")
     adata_filename = f"{exp_name}.project.h5ad"
     adata.write(f"{bundle_subdir}/{adata_filename}")

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -801,9 +801,15 @@ def scale_matrix_in_anndata(
     """
 
     if "raw." in slot:
-        adata.raw.X = scale_matrix(
+        # can't update .raw.X directly, so try some walk-around
+        raw_X_scale = scale_matrix(
             adata.raw.X, scale, reverse_transform=reverse_transform
-        )
+        ) # calculate the scaled matrix
+        X_org = adata.X # backup .X
+        adata = adata.raw.to_adata() # transfer adata.raw object to adata object
+        adata.X = raw_X_scale # update new adata.X to be the scaled matrix
+        adata.raw = adata # move the object back to .raw
+        adata.X = X_org # save the original .X back
     elif slot == "X":
         adata.X = scale_matrix(
             adata.X, scale, reverse_transform=reverse_transform

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -802,14 +802,9 @@ def scale_matrix_in_anndata(
 
     if "raw." in slot:
         # can't update .raw.X directly, so try some walk-around
-        raw_X_scale = scale_matrix(
+        adata.raw._X = scale_matrix(
             adata.raw.X, scale, reverse_transform=reverse_transform
-        ) # calculate the scaled matrix
-        X_org = adata.X # backup .X
-        adata = adata.raw.to_adata() # transfer adata.raw object to adata object
-        adata.X = raw_X_scale # update new adata.X to be the scaled matrix
-        adata.raw = adata # move the object back to .raw
-        adata.X = X_org # save the original .X back
+        )
     elif slot == "X":
         adata.X = scale_matrix(
             adata.X, scale, reverse_transform=reverse_transform

--- a/atlas_anndata/funcs.py
+++ b/atlas_anndata/funcs.py
@@ -1003,7 +1003,7 @@ def write_cell_metadata(
     precells_filename = f"mage-tab/{exp_name}.precells.txt"
 
     cell_metadata, run_metadata, cell_specific_metadata = derive_metadata(
-        adata, config=config, kind=None
+        adata, config=config, kind=kind
     )
 
     # Output the total cell metadata anyway

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = ["setuptools", "wheel"]
 
 [tool.black]
-experimental-string-processing = true
 line-length = 79
 include = '\.pyi?|bin/*$'
 exclude = '''


### PR DESCRIPTION
We have detected few issues that imped compatibility with SCXA loading process.

1. software_versions_file is expected in the MANIFEST file  `analysis_versions_file	software.tsv`
2. The embedding must show a numeric value here
```
umap_embeddings	umap.tsv	[{"name": "X_umap"}]
```
3. The log for E-ANND-3 shows 

> No cell groupings have markers specified, skipping writing of markers and stats

we need to ensure generation of markers and stats is attempted.

4. in ANND experiments, the matrix directories (`tpm_filtered` , `raw_filtered` , `filtered_normalised` , `raw` ) are all under `$EXP_BUNDLE/matrices`  directory, but in a regular experiment, they are all just saved under `$EXP_BUNDLE`, as in `$EXP_BUNDLE/raw` for example.  We need to correct this in the `atlas-anndata` code. Currently, having the matrix dirs saved in the `$EXP_BUNDLE/matrices` subdirectory causes silent errors in loading.
`filtered_normalised` is required. Loading script will copy also `tpm_filtered` , `raw_filtered` and `raw` , if present.

5. Reference files (GTF, cDNA) used in analysis are needed in an ANND bundle, and these files should be specified in the MANIFEST with the lines `reference_annotation` and `reference_transcriptome`.